### PR TITLE
Bugfix: ICMPv4 TYPE match using incorrect enum.

### DIFF
--- a/fluid/of13/of13match.cc
+++ b/fluid/of13/of13match.cc
@@ -990,7 +990,7 @@ of_error SCTPDst::unpack(uint8_t *buffer) {
 }
 
 ICMPv4Type::ICMPv4Type(uint8_t value)
-    : OXMTLV(of13::OFPXMC_OPENFLOW_BASIC, of13::OFPXMT_OFB_ICMPV4_CODE, false,
+    : OXMTLV(of13::OFPXMC_OPENFLOW_BASIC, of13::OFPXMT_OFB_ICMPV4_TYPE, false,
         of13::OFP_OXM_ICMP_TYPE_LEN) {
     this->value_ = value;
     create_oxm_req(0x0800, 0, 1, 0);


### PR DESCRIPTION
Fix ICMPv4 TYPE match field to use OFPXMT_OFB_ICMPV4_TYPE instead of
OFPXMT_OFB_ICMPV4_CODE.
