### PR TITLE
Bugfix: Incorrect length when using masked matches.

### DIFF
--- a/fluid/of13/of13match.cc
+++ b/fluid/of13/of13match.cc
@@ -52,7 +52,7 @@ OXMTLV::OXMTLV(uint16_t class_, uint8_t field, bool has_mask, uint8_t length)
     : class__(class_),
       field_(field),
       has_mask_(has_mask),
-      length_(length) {
+      length_(has_mask?length<<1:length) {
 }
 
 bool OXMTLV::equals(const OXMTLV &other) {


### PR DESCRIPTION
Fix OXMTLV to have the correct length (double the given length) when
masks are used.
