### PR TITLE
Bugfix: Clear-Actions instruction too long.

### DIFF
--- a/fluid/of13/of13instruction.hh
+++ b/fluid/of13/of13instruction.hh
@@ -214,7 +214,7 @@ private:
 public:
     ClearActions()
         : Instruction(of13::OFPIT_CLEAR_ACTIONS,
-              sizeof(struct of13::ofp_instruction) + 4),
+              sizeof(struct of13::ofp_instruction)),
           set_order_(30) {
     }
     ~ClearActions() {


### PR DESCRIPTION
Clear-Actions instruction must contain no actions, and must
total 8 bytes in length (not 12).
