### PR TITLE
Bugfix: segfault with duplicate match fields.

### DIFF
--- a/fluid/of13/of13match.cc
+++ b/fluid/of13/of13match.cc
@@ -2296,13 +2296,13 @@ bool Match::check_dup(OXMTLV *tlv) {
 }
 
 void Match::add_oxm_field(OXMTLV &tlv) {
-    this->curr_tlvs_.push_back(tlv.field());
+    if (!check_dup(&tlv)) this->curr_tlvs_.push_back(tlv.field());
     this->oxm_tlvs_[tlv.field()] = tlv.clone();
     this->length_ += of13::OFP_OXM_HEADER_LEN + tlv.length();
 }
 
 void Match::add_oxm_field(OXMTLV* tlv) {
-    this->curr_tlvs_.push_back(tlv->field());
+    if (!check_dup(tlv)) this->curr_tlvs_.push_back(tlv->field());
     this->oxm_tlvs_[tlv->field()] = tlv;
     this->length_ += of13::OFP_OXM_HEADER_LEN + tlv->length();
 }


### PR DESCRIPTION
Duplicate match fields caused a segfault in the destructor due to the
field num being present multiple times in the cur_tlvs_ vector, and the
destructor iterating over those entries and consequently deleting entries
in the oxm_tlvs_ multiple times. For reference, the destructor looks
like this:
Match::~Match() {
    for (std::vector<uint8_t>::iterator it = this->curr_tlvs_.begin();
        it != this->curr_tlvs_.end(); ++it) {
        delete this->oxm_tlvs_[*it];
    }
}
