### PR TITLE
Bugfix: duplicate match fields incorrect length.

### DIFF
--- a/fluid/of13/of13match.cc
+++ b/fluid/of13/of13match.cc
@@ -2547,13 +2547,15 @@ bool Match::check_dup(OXMTLV *tlv) {
 }
 
 void Match::add_oxm_field(OXMTLV &tlv) {
-    if (!check_dup(&tlv)) this->curr_tlvs_.push_back(tlv.field());
+    if (check_dup(&tlv)) return;
+    this->curr_tlvs_.push_back(tlv.field());
     this->oxm_tlvs_[tlv.field()] = tlv.clone();
     this->length_ += of13::OFP_OXM_HEADER_LEN + tlv.length();
 }
 
 void Match::add_oxm_field(OXMTLV* tlv) {
-    if (!check_dup(tlv)) this->curr_tlvs_.push_back(tlv->field());
+    if (check_dup(tlv)) return;
+    this->curr_tlvs_.push_back(tlv->field());
     this->oxm_tlvs_[tlv->field()] = tlv;
     this->length_ += of13::OFP_OXM_HEADER_LEN + tlv->length();
 }


### PR DESCRIPTION
Previous fix prevented the segfault, but duplicate matches were still
causing incorrect OpenFlow flowmods on the wire, causing error reply
with type=OFPET_BAD_MATCH and code=OFPBMC_BAD_LEN. This changeset
ignores calls to duplicate fields altogether, and now works correctly on
the wire.