### PR TITLE
Openflow 1.0: correctly match against network addresses

### DIFF
--- a/fluid/of10/of10match.cc
+++ b/fluid/of10/of10match.cc
@@ -83,26 +83,26 @@ void Match::nw_proto(uint8_t nw_proto) {
 
 void Match::nw_src(const IPAddress &nw_src) {
     this->nw_src_ = nw_src;
-    this->wildcards_ &= ~of10::OFPFW_NW_DST_ALL;
+    this->wildcards_ &= ~of10::OFPFW_NW_SRC_MASK;
 }
 
 void Match::nw_dst(const IPAddress &nw_dst) {
     this->nw_dst_ = nw_dst;
-    this->wildcards_ &= ~of10::OFPFW_NW_SRC_ALL;
+    this->wildcards_ &= ~of10::OFPFW_NW_DST_MASK;
 }
 
 void Match::nw_src(const IPAddress &nw_src, uint32_t prefix) {
     this->nw_src_ = nw_src;
     uint32_t index = 32 - prefix;
     this->wildcards_ &= ~of10::OFPFW_NW_SRC_MASK;
-    this->wildcards_ |= ((32 - index) << of10::OFPFW_NW_SRC_SHIFT);
+    this->wildcards_ |= (index << of10::OFPFW_NW_SRC_SHIFT);
 }
 
 void Match::nw_dst(const IPAddress &nw_dst, uint32_t prefix) {
     this->nw_dst_ = nw_dst;
     uint32_t index = 32 - prefix;
     this->wildcards_ &= ~of10::OFPFW_NW_DST_MASK;
-    this->wildcards_ |= ((32 - prefix) << of10::OFPFW_NW_DST_SHIFT);
+    this->wildcards_ |= (index << of10::OFPFW_NW_DST_SHIFT);
 }
 
 void Match::tp_src(uint16_t tp_src) {


### PR DESCRIPTION
The changes to Match::nw_*(const IPAddress &, uint32_t) should be self-explanatory.

As for Match::nw_(const IPAddress &, uint32_t), OFPFW_NW_ALL serves an entirely different purpose (OFPFW_NWALL == 32 << OFPFW_NWSHIFT; so XORing against it leaves you with /1, rather than /32). The constant you are looking for is OFPFW_NW*_MASK. (Jedi mind trick: "These are not the constants you are looking for.")
