### PR TITLE
Setfield

### DIFF
--- a/fluid/of13/of13action.hh
+++ b/fluid/of13/of13action.hh
@@ -323,6 +323,9 @@ public:
     uint16_t set_order() const {
         return this->set_order_;
     }
+    virtual uint16_t set_sub_order() const {
+	return this->field_ ? this->field_->field() : 0;
+    }
     size_t pack(uint8_t *buffer);
     of_error unpack(uint8_t *buffer);
     virtual SetFieldAction* clone() {

--- a/fluid/of13/of13instruction.cc
+++ b/fluid/of13/of13instruction.cc
@@ -251,13 +251,15 @@ void WriteActions::actions(ActionSet actions) {
 }
 
 void WriteActions::add_action(Action &action) {
-    this->actions_.add_action(action);
-    this->length_ += action.length();
+    if (this->actions_.add_action(action)) {
+	this->length_ += action.length();
+    }
 }
 
 void WriteActions::add_action(Action* action) {
-    this->actions_.add_action(action);
-    this->length_ += action->length();
+    if (this->actions_.add_action(action)) {
+	this->length_ += action->length();
+    }
 }
 
 size_t WriteActions::pack(uint8_t* buffer) {

--- a/fluid/ofcommon/action.cc
+++ b/fluid/ofcommon/action.cc
@@ -212,15 +212,20 @@ void swap(ActionSet& first, ActionSet& second) {
     std::swap(first.action_set_, second.action_set_);
 }
 
-void ActionSet::add_action(Action &act) {
+bool ActionSet::add_action(Action &act) {
     Action *actn = act.clone();
-    this->action_set_.insert(actn);
-    this->length_ += act.length();
+    return this->add_action(actn);
 }
 
-void ActionSet::add_action(Action *act) {
-    this->action_set_.insert(act);
-    this->length_ += act->length();
+bool ActionSet::add_action(Action *act) {
+    // Set items are unique.  Only update length if
+    // actually inserted.
+    bool added = this->action_set_.insert(act).second;
+    if (added) {
+	this->length_ += act->length();
+    }
+
+    return added;
 }
 
 } //End of namespace fluid_msg

--- a/fluid/ofcommon/action.hh
+++ b/fluid/ofcommon/action.hh
@@ -29,6 +29,9 @@ public:
     virtual uint16_t set_order() const {
         return 0;
     }
+    virtual uint16_t set_sub_order() const {
+	return 0;
+    }
     uint16_t type() {
         return this->type_;
     }
@@ -84,6 +87,9 @@ public:
 
 struct comp_action_set_order {
     bool operator()(Action * lhs, Action* rhs) const {
+	if (lhs->set_order() == rhs->set_order()) {
+	    return lhs->set_sub_order() < rhs->set_sub_order();
+	}
         return lhs->set_order() < rhs->set_order();
     }
 };
@@ -112,8 +118,8 @@ public:
     std::set<Action*, comp_action_set_order> action_set(){
         return this->action_set_;
     }
-    void add_action(Action &action);
-    void add_action(Action *act);
+    bool add_action(Action &action);
+    bool add_action(Action *act);
     void length(uint16_t length) {
         this->length_ = length;
     }

--- a/test/multipart_test.cc
+++ b/test/multipart_test.cc
@@ -338,7 +338,7 @@ TEST(MultipartReply, MultipartReplyMeter){
 }
 
 TEST(MultipartRequest, MultipartRequestMeterConfig){
-  of13::MultipartRequestMeterConfig src(xid, 0);
+  of13::MultipartRequestMeterConfig src(xid, 0, 1);
   uint8_t* buffer  = src.pack();
   of13::MultipartRequestMeterConfig dst;
   dst.unpack(buffer);


### PR DESCRIPTION
This fix addresses an issue where if you have multiple set field actions in a write action, they aren't handled correctly:
- a duplicate set field action changes length and shouldn't
- a unique set field action should be added to write action

The code adds the possibility of a sub-ordering for the ActionSet.  This was done via a virtual function in Action().  SetFieldAction() overrides this and uses the field id.  The ActionSet comparison function for the underlying C++ set considers the sub-order if the primary ordering key is equal.

Tests were added to highlight the issues and that the change addresses them.  The tests were not initially compiling so there's a small commit to address that.