### PR TITLE
Fix PacketIn's length and padding calculation

### DIFF
--- a/fluid/of13/of13instruction.hh
+++ b/fluid/of13/of13instruction.hh
@@ -76,6 +76,7 @@ public:
     }    
     void add_instruction(Instruction &inst);
     void add_instruction(Instruction *inst);
+    Instruction * release_instruction(uint16_t type);
     void length(uint16_t length) {
         this->length_ = length;
     }
@@ -176,6 +177,7 @@ public:
     void actions(ActionSet actions);
     void add_action(Action &action);
     void add_action(Action* action);
+    Action* release_action(uint16_t type);
 };
 
 class ApplyActions: public Instruction {
@@ -206,6 +208,7 @@ public:
     void actions(ActionList actions);
     void add_action(Action &action);
     void add_action(Action* action);
+    std::list<Action*> release_actions();
 };
 
 class ClearActions: public Instruction {

--- a/fluid/of13msg.cc
+++ b/fluid/of13msg.cc
@@ -648,6 +648,14 @@ void FlowMod::add_instruction(Instruction* inst) {
     this->length_ += inst->length();
 }
 
+Instruction * FlowMod::release_instruction(uint16_t type) {
+    Instruction * inst = this->instructions_.release_instruction(type);
+    if (!inst)
+        return NULL;
+    this->length_ -= inst->length();
+    return inst;
+}
+
 FlowRemoved::FlowRemoved()
     : FlowRemovedCommon(of13::OFP_VERSION, of13::OFPT_FLOW_REMOVED),
       table_id_(0),

--- a/fluid/of13msg.cc
+++ b/fluid/of13msg.cc
@@ -445,7 +445,7 @@ PacketIn::PacketIn(uint32_t xid, uint32_t buffer_id, uint16_t total_len,
 
 uint16_t PacketIn::length() {
     return sizeof(struct of13::ofp_packet_in) - sizeof(struct of13::ofp_match)
-        + ROUND_UP(this->match_.length(), 8) + this->data_len_;
+        + ROUND_UP(this->match_.length(), 8) + this->data_len_ + 2;
 }
 
 bool PacketIn::operator==(const PacketIn &other) const {
@@ -461,9 +461,7 @@ bool PacketIn::operator!=(const PacketIn &other) const {
 uint8_t* PacketIn::pack() {
     this->length_ = length();
     uint8_t* buffer = OFMsg::pack();
-    size_t padding = ROUND_UP(
-        sizeof(struct of13::ofp_packet_in) - 4 + this->match_.length(), 8)
-        - (sizeof(struct of13::ofp_packet_in) - 4 + this->match_.length());
+    size_t padding = ROUND_UP(this->match_.length(), 8) - this->match_.length();
     struct of13::ofp_packet_in *pi = (struct of13::ofp_packet_in*) buffer;
     pi->buffer_id = hton32(this->buffer_id_);
     pi->total_len = hton16(this->total_len_);

--- a/fluid/of13msg.hh
+++ b/fluid/of13msg.hh
@@ -395,6 +395,7 @@ public:
     void instructions(InstructionSet instructions);
     void add_instruction(Instruction &inst);
     void add_instruction(Instruction* inst);
+    Instruction * release_instruction(uint16_t type);
 };
 
 /**

--- a/fluid/ofcommon/action.cc
+++ b/fluid/ofcommon/action.cc
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "action.hh"
 
 namespace fluid_msg {
@@ -135,6 +136,18 @@ void ActionList::add_action(Action * act) {
     this->length_ += act->length();
 }
 
+std::list<Action *> ActionList::release_actions() {
+    std::list<Action*> result;
+    typedef std::list<Action*>::iterator iterator_t;
+    for (iterator_t it = this->action_list_.begin(); it != this->action_list_.end(); ++it) {
+        Action * act = *it;
+        this->length_ -= act->length();
+        result.push_back(act);
+    }
+    this->action_list_.clear();
+    return result;
+}
+
 ActionSet::ActionSet(std::set<Action*> action_set) {
     this->action_set_ = action_set_;
     for (std::set<Action*>::const_iterator it = action_set.begin();
@@ -221,6 +234,19 @@ void ActionSet::add_action(Action &act) {
 void ActionSet::add_action(Action *act) {
     this->action_set_.insert(act);
     this->length_ += act->length();
+}
+
+Action * ActionSet::release_action(uint16_t type) {
+    typedef std::set<Action *, comp_action_set_order>::iterator iterator_t;
+    for (iterator_t it = this->action_set_.begin(); it != this->action_set_.end(); ++it) {
+        if ((*it)->type() == type) {
+            Action* act = *it;
+            this->length_ -= act->length();
+            this->action_set_.erase(it);
+            return act;
+        }
+    }
+    return NULL;
 }
 
 } //End of namespace fluid_msg

--- a/fluid/ofcommon/action.hh
+++ b/fluid/ofcommon/action.hh
@@ -77,6 +77,7 @@ public:
     }
     void add_action(Action &action);
     void add_action(Action *act);
+    std::list<Action *> release_actions();
     void length(uint16_t length) {
         this->length_ = length;
     }
@@ -114,6 +115,7 @@ public:
     }
     void add_action(Action &action);
     void add_action(Action *act);
+    Action * release_action(uint16_t type);
     void length(uint16_t length) {
         this->length_ = length;
     }


### PR DESCRIPTION
According to the OF13 specs the __packet_in__ message has an additional padding of two bytes. Which was taken into account during packing/unpacking, but was forgotten in `PacketIn::length()`.

Moreover, padding is for the __ofp_match__ only. The old code was doing something I couldn't understand.

Please correct me if I'm wrong. I was getting broken __packet_in__ messages until I made those changes.