### PR TITLE
Fixed actions length in PacketOut::unpack function (of13) (caused unpack to display no actions)

### DIFF
--- a/fluid/of13msg.cc
+++ b/fluid/of13msg.cc
@@ -415,6 +415,7 @@ of_error PacketOut::unpack(uint8_t *buffer) {
     this->buffer_id_ = ntoh32(po->buffer_id);
     this->in_port_ = ntoh32(po->in_port);
     this->actions_len_ = ntoh16(po->actions_len);
+    this->actions_.length(this->actions_len_);
     size_t len = this->actions_len_;
     uint8_t * p = buffer + sizeof(struct of13::ofp_packet_out);
     this->actions_.unpack13(p);
@@ -445,7 +446,7 @@ PacketIn::PacketIn(uint32_t xid, uint32_t buffer_id, uint16_t total_len,
 
 uint16_t PacketIn::length() {
     return sizeof(struct of13::ofp_packet_in) - sizeof(struct of13::ofp_match)
-        + ROUND_UP(this->match_.length(), 8) + this->data_len_;
+        + ROUND_UP(this->match_.length(), 8) + this->data_len_ + 2;
 }
 
 bool PacketIn::operator==(const PacketIn &other) const {
@@ -461,9 +462,7 @@ bool PacketIn::operator!=(const PacketIn &other) const {
 uint8_t* PacketIn::pack() {
     this->length_ = length();
     uint8_t* buffer = OFMsg::pack();
-    size_t padding = ROUND_UP(
-        sizeof(struct of13::ofp_packet_in) - 4 + this->match_.length(), 8)
-        - (sizeof(struct of13::ofp_packet_in) - 4 + this->match_.length());
+    size_t padding = ROUND_UP(this->match_.length(), 8) - this->match_.length();
     struct of13::ofp_packet_in *pi = (struct of13::ofp_packet_in*) buffer;
     pi->buffer_id = hton32(this->buffer_id_);
     pi->total_len = hton16(this->total_len_);

--- a/fluid/of13msg.cc
+++ b/fluid/of13msg.cc
@@ -446,7 +446,7 @@ PacketIn::PacketIn(uint32_t xid, uint32_t buffer_id, uint16_t total_len,
 
 uint16_t PacketIn::length() {
     return sizeof(struct of13::ofp_packet_in) - sizeof(struct of13::ofp_match)
-        + ROUND_UP(this->match_.length(), 8) + this->data_len_ + 2;
+        + ROUND_UP(this->match_.length(), 8) + this->data_len_;
 }
 
 bool PacketIn::operator==(const PacketIn &other) const {
@@ -462,7 +462,9 @@ bool PacketIn::operator!=(const PacketIn &other) const {
 uint8_t* PacketIn::pack() {
     this->length_ = length();
     uint8_t* buffer = OFMsg::pack();
-    size_t padding = ROUND_UP(this->match_.length(), 8) - this->match_.length();
+    size_t padding = ROUND_UP(
+        sizeof(struct of13::ofp_packet_in) - 4 + this->match_.length(), 8)
+        - (sizeof(struct of13::ofp_packet_in) - 4 + this->match_.length());
     struct of13::ofp_packet_in *pi = (struct of13::ofp_packet_in*) buffer;
     pi->buffer_id = hton32(this->buffer_id_);
     pi->total_len = hton16(this->total_len_);


### PR DESCRIPTION
I was struggling with the fact that was unable to get any Actions from PacketOut messages in of13, and realized that the unpack function was missing a step also taken in of10::PacketOut::unpack, which was to set the lenght of the actions_ variable.

Adding this it's now possible to get all the actions encapsulated in a of13 PacketOut message.

Furthermore, I ended up also committing the code fix in [this pull request](https://github.com/OpenNetworkingFoundation/libfluid_msg/pull/15) regarding the PacketIn lenght. Hope that's not a problem.