### PR TITLE
Fix PacketIn's length and padding calculation (reopened)

### DIFF
--- a/fluid/of13msg.cc
+++ b/fluid/of13msg.cc
@@ -445,7 +445,7 @@ PacketIn::PacketIn(uint32_t xid, uint32_t buffer_id, uint16_t total_len,
 
 uint16_t PacketIn::length() {
     return sizeof(struct of13::ofp_packet_in) - sizeof(struct of13::ofp_match)
-        + ROUND_UP(this->match_.length(), 8) + this->data_len_;
+        + ROUND_UP(this->match_.length(), 8) + this->data_len_ + 2;
 }
 
 bool PacketIn::operator==(const PacketIn &other) const {
@@ -461,9 +461,7 @@ bool PacketIn::operator!=(const PacketIn &other) const {
 uint8_t* PacketIn::pack() {
     this->length_ = length();
     uint8_t* buffer = OFMsg::pack();
-    size_t padding = ROUND_UP(
-        sizeof(struct of13::ofp_packet_in) - 4 + this->match_.length(), 8)
-        - (sizeof(struct of13::ofp_packet_in) - 4 + this->match_.length());
+    size_t padding = ROUND_UP(this->match_.length(), 8) - this->match_.length();
     struct of13::ofp_packet_in *pi = (struct of13::ofp_packet_in*) buffer;
     pi->buffer_id = hton32(this->buffer_id_);
     pi->total_len = hton16(this->total_len_);


### PR DESCRIPTION
According to the OF13 specs the __packet_in__ message has an additional padding of two bytes. Which was taken into account during packing/unpacking, but was forgotten in `PacketIn::length()`.

Moreover, padding is for the __ofp_match__ only. The old code was doing something I couldn't understand.

Please correct me if I'm wrong. I was getting broken __packet_in__ messages until I made those changes.

(reopening #15 because I decided to restructure branches in my fork)