### PR TITLE
Fix Group and Meter Features Reply length calculation

### DIFF
--- a/fluid/of13/of13meter.hh
+++ b/fluid/of13/of13meter.hh
@@ -209,7 +209,7 @@ public:
     void max_meter(uint32_t max_meter) {
         this->max_meter_ = max_meter;
     }
-    void banc_types(uint32_t band_types) {
+    void band_types(uint32_t band_types) {
         this->band_types_ = band_types;
     }
     void capabilities(uint32_t capabilities) {

--- a/fluid/of13msg.cc
+++ b/fluid/of13msg.cc
@@ -1985,6 +1985,7 @@ of_error MultipartRequestGroupFeatures::unpack(uint8_t *buffer) {
 
 MultipartReplyGroupFeatures::MultipartReplyGroupFeatures()
     : MultipartReply(OFPMP_GROUP_FEATURES) {
+    this->length_ += sizeof(struct of13::ofp_group_features);
 }
 
 MultipartReplyGroupFeatures::MultipartReplyGroupFeatures(uint32_t xid,
@@ -2273,6 +2274,7 @@ of_error MultipartRequestMeterFeatures::unpack(uint8_t *buffer) {
 
 MultipartReplyMeterFeatures::MultipartReplyMeterFeatures()
     : MultipartReply(OFPMP_METER_FEATURES) {
+    this->length_ += sizeof(struct of13::ofp_meter_features);
 }
 
 MultipartReplyMeterFeatures::MultipartReplyMeterFeatures(uint32_t xid,


### PR DESCRIPTION
The length for MultipartReplyGroupFeatures and MultipartReplyMeterFeatures was not set for every constructor. This patch just adds the length calculation to each constructor.

I also fixed a spelling error in a MeterFeatures getter function. This is a change in API which might break someone else their code so if it's better to just leave it I can revert that commit.