### PR TITLE
Fix groupmod length calculation

### DIFF
--- a/fluid/of13msg.cc
+++ b/fluid/of13msg.cc
@@ -861,6 +861,7 @@ bool GroupMod::operator!=(const GroupMod &other) const {
 }
 
 void GroupMod::buckets(std::vector<Bucket> buckets) {
+    this->length_ -= buckets_len();
     this->buckets_ = buckets;
     this->length_ += buckets_len();
 }


### PR DESCRIPTION
I apparently am doing something weird where I receive packets, edit them,and then send them out again. If a GroupMod already contains buckets will the length be incorrect after replacing them with new buckets.
I think this problem occurs in every function that contains "this->length_ +=", isn't a constructor and doesn't contain the string "add" in the function name. I'm not going to try and change all of them.
I also looked at the of13::FlowMod class since I also use that one a lot, the functions of13::FlowMod::match and of13::FlowMod::instructions technically have the same problem but the length of the of13::FlowMod packet is recalculated in the pack function so there is no benefit to changing them.