### PR TITLE
Fixed ipv4 with mask field match

### DIFF
--- a/fluid/of13/of13match.cc
+++ b/fluid/of13/of13match.cc
@@ -642,7 +642,7 @@ IPv4Src::IPv4Src(IPAddress value)
 
 IPv4Src::IPv4Src(IPAddress value, IPAddress mask)
     : OXMTLV(of13::OFPXMC_OPENFLOW_BASIC, of13::OFPXMT_OFB_IPV4_SRC, true,
-          of13::OFP_OXM_IPV4_LEN),
+          of13::OFP_OXM_IPV4_WITH_MASK_LEN),
       value_(value),
       mask_(mask) {
     // this->value_  = value;
@@ -707,7 +707,7 @@ IPv4Dst::IPv4Dst(IPAddress value)
 
 IPv4Dst::IPv4Dst(IPAddress value, IPAddress mask)
     : OXMTLV(of13::OFPXMC_OPENFLOW_BASIC, of13::OFPXMT_OFB_IPV4_DST, true,
-          of13::OFP_OXM_IPV4_LEN),
+          of13::OFP_OXM_IPV4_WITH_MASK_LEN),
       value_(value),
       mask_(mask) {
     // this->value_  = value;

--- a/fluid/of13/openflow-13.h
+++ b/fluid/of13/openflow-13.h
@@ -244,6 +244,7 @@ const uint8_t OFP_OXM_IP_DSCP_LEN = 1;
 const uint8_t OFP_OXM_IP_ECN_LEN = 1;
 const uint8_t OFP_OXM_IP_PROTO_LEN = 1;
 const uint8_t OFP_OXM_IPV4_LEN = 4;
+const uint8_t OFP_OXM_IPV4_WITH_MASK_LEN = 8;
 const uint8_t OFP_OXM_TP_LEN = 2;
 const uint8_t OFP_OXM_ARP_OP_LEN = 2;
 const uint8_t OFP_OXM_ICMP_TYPE_LEN = 1;


### PR DESCRIPTION
IPv4 src/dst matching was not working when a mask was added. For example, if you tried:
```c++
of13::IPv4Dst *ip_match = new of13::IPv4Dst("20.20.20.0", "255.255.255.0");
fm.add_oxm_field(ip_match);
```
and sent the flow mod, ovs would complain and say `Rejecting NXM/OXM entry 0:32768:12:1:8 with 1-bits in value for bits wildcarded by mask`. This happens because the field length is incorrectly set as 4 bytes for both IPv4 without a mask and IPv4 with a mask. When a mask is added, the field length must be set as 8 bytes. This change corrects the length when using a mask.